### PR TITLE
Incorrect PWD with bric_ftpd

### DIFF
--- a/lib/Bric/Changes.pod
+++ b/lib/Bric/Changes.pod
@@ -47,6 +47,18 @@ upshot is that files will now be distributed much sooner after publishling.
 
 =back
 
+=head2 Bug Fixes
+
+=over
+
+=item *
+
+Fixed bug in bric_ftpd where the ftp PWD command returns an incorrect path
+(missing the site name).  Some ftp clients (eg. FileZilla) call PWD and use
+this path after changing directories. [Adrian Yee]
+
+=back
+
 =head1 Version 2.0.1 ()
 
 =head1 Improvements

--- a/lib/Bric/Util/FTP/DirHandle.pm
+++ b/lib/Bric/Util/FTP/DirHandle.pm
@@ -163,8 +163,9 @@ sub get {
           # Find the root category.
           my ($cid) = Bric::Biz::Category->list_ids({ site_id => $site_id,
                                                       uri     => '/' });
+          my $site = Bric::Biz::Site->lookup({ id => $site_id });
           return Bric::Util::FTP::DirHandle->new($self->{ftps},
-                                                 "/" . $filename . "/",
+                                                 "/" . $site->get_name . "/" . $filename . "/",
                                                  $site_id,
                                                  $id,
                                                  $cid,
@@ -384,6 +385,10 @@ sub list {
       my @ocs  = Bric::Biz::OutputChannel->list({name => ($like || '%'),
                                                  site_id => $site_id,
                                                  active => 1});
+
+      my $site = Bric::Biz::Site->lookup({ id => $site_id });
+      my $site_name = $site->get_name;
+
       foreach my $oc (@ocs) {
           next unless $self->{ftps}{user_obj}->can_do($oc, READ);
 
@@ -392,7 +397,7 @@ sub list {
                                                       uri     => '/' });
 
           my $dirh = Bric::Util::FTP::DirHandle->new($self->{ftps},
-                                                     "/" . $oc->get_name . "/",
+                                                     "/$site_name/" . $oc->get_name . "/",
                                                      $site_id,
                                                      $oc->get_id(),
                                                      $cid);


### PR DESCRIPTION
Fixed bug in bric_ftpd where the ftp PWD command returns an incorrect path (missing the site name).  Some ftp clients (eg. FileZilla) call PWD and use this path after changing directories.Fixed bug in bric_ftpd where the ftp PWD command returns an incorrect path (missing the site name).  Some ftp clients (eg. FileZilla) call PWD and use this path after changing directories.
