### PR TITLE
Fix for bug #183

### DIFF
--- a/lib/Bric/Changes.pod
+++ b/lib/Bric/Changes.pod
@@ -82,6 +82,10 @@ this path after changing directories. [Adrian Yee]
 In the event of a publish failure, a story and media document no longer has
 its publish status, date, and first publish date updated (Bug #200). [David]
 
+=item *
+
+Using pagination controls when selecting from a list of stories to relate no
+longer throws an error (Bug #183). [Greg Heo]
 
 =back
 


### PR DESCRIPTION
The id parameter is not preserved in pagination links when browsing a list of stories to relate to the current story. This fix adds it back in.
