### PR TITLE
Fix for bug #230

### DIFF
--- a/lib/Bric/Biz/ElementType/Subelement.pm
+++ b/lib/Bric/Biz/ElementType/Subelement.pm
@@ -301,6 +301,7 @@ sub href {
     my @params;
     my $wheres = $pkg->SEL_WHERES
                . ' AND a.id = subet.child_id AND '
+               . " a.active = '1' AND "
                . any_where $p->{parent_id}, 'subet.parent_id = ?', \@params;
     my $sel = prepare_c(qq{
         SELECT $cols


### PR DESCRIPTION
Inactive subelements will no longer appear in the list of elements to add to a story profile or in the list of subelements in the element type definition.
