### PR TITLE
Fixed #201: Deactived assets still have "Republish" checkbox in UI when using "Find Stories"

### DIFF
--- a/comp/workflow/manager/dhandler
+++ b/comp/workflow/manager/dhandler
@@ -73,6 +73,7 @@ my $select = sub {
         # Add a republish checkbox
     if ($type ne 'template' && $o->get_publish_status
         && !$o->get_workflow_id && chk_authz($o, PUBLISH, 1)
+        && $o->is_active
     ) {
         push @$ret, [
             $lang->maketext('Republish'),


### PR DESCRIPTION
Added one more check to restrict the "Republish" checkbox from appearing for deactivated items.
