### PR TITLE
Fix (un)expired search to really be a boolean

### DIFF
--- a/lib/Bric/Biz/Asset/Business/Media.pm
+++ b/lib/Bric/Biz/Asset/Business/Media.pm
@@ -228,7 +228,8 @@ use constant PARAM_WHERE_MAP => {
       cover_date_end        => 'i.cover_date <= ?',
       expire_date_start     => 'i.expire_date >= ?',
       expire_date_end       => 'i.expire_date <= ?',
-      unexpired             => '(i.expire_date IS NULL OR i.expire_date > CURRENT_TIMESTAMP)',
+      unexpired             => '((i.expire_date IS NULL OR i.expire_date > CURRENT_TIMESTAMP)=?)',
+      expired               => '((i.expire_date IS NOT NULL AND i.expire_date <= CURRENT_TIMESTAMP)=?)',
       desk_id               => 'mt.desk__id = ?',
       name                  => 'LOWER(i.name) LIKE LOWER(?)',
       subelement_key_name   => 'i.id = mct.object_instance_id AND mct.element_type__id = subet.id AND LOWER(subet.key_name) LIKE LOWER(?)',
@@ -741,8 +742,13 @@ Returns a list of media with a expire date on or before a given date/time.
 
 =item unexpired
 
-A boolean parameter. Returns a list of media without an expire date, or with
-an expire date set in the future.
+A boolean value indicating whether to return only unexpired stories (i.e.
+without an expire date or one set in the future).
+
+=item expired
+
+A boolean value indicating whether to return only expired stories (i.e. where
+the expire date is in the past).
 
 =item element_key_name
 

--- a/lib/Bric/Biz/Asset/Business/Story.pm
+++ b/lib/Bric/Biz/Asset/Business/Story.pm
@@ -334,7 +334,8 @@ use constant PARAM_WHERE_MAP => {
       cover_date_end         => 'i.cover_date <= ?',
       expire_date_start      => 'i.expire_date >= ?',
       expire_date_end        => 'i.expire_date <= ?',
-      unexpired              => '(i.expire_date IS NULL OR i.expire_date > CURRENT_TIMESTAMP)',
+      unexpired              => '((i.expire_date IS NULL OR i.expire_date > CURRENT_TIMESTAMP)=?)',
+      expired                => '((i.expire_date IS NOT NULL AND i.expire_date <= CURRENT_TIMESTAMP)=?)',
       desk_id                => 's.desk__id = ?',
       name                   => 'LOWER(i.name) LIKE LOWER(?)',
       subelement_key_name    => 'i.id = sct.object_instance_id AND sct.element_type__id = subet.id AND LOWER(subet.key_name) LIKE LOWER(?)',
@@ -865,8 +866,13 @@ Returns a list of stories with a expire date on or before a given date/time.
 
 =item unexpired
 
-A boolean parameter. Returns a list of stories without an expire date, or with
-an expire date set in the future.
+A boolean value indicating whether to return only unexpired stories (i.e.
+without an expire date or one set in the future).
+
+=item expired
+
+A boolean value indicating whether to return only expired stories (i.e. where
+the expire date is in the past).
 
 =item element_key_name
 


### PR DESCRIPTION
Allow unexpired => 0/1 and the reverse expired => 0/1.

Not sure if the SQL style ((where clause) = 1) is completely up to the standard but it works. Alternate plan: just make it an "on" switch where { unexpired => 1} and { expired => 1 } are opposites.
