### PR TITLE
Fix for #252: RELATED_MEDIA_UPLOAD dialog messages

### DIFF
--- a/comp/widgets/profile/media_upload.mc
+++ b/comp/widgets/profile/media_upload.mc
@@ -9,6 +9,7 @@
     req        => 1,
     objs       => \@elems,
     useTable   => 0,
+    default    => ['',''],
 &></td>
     <td><input type="file" name="<% $file_widget %>|file" /></td>
     <td align="right">

--- a/lib/Bric/App/Callback/ContainerProf.pm
+++ b/lib/Bric/App/Callback/ContainerProf.pm
@@ -205,7 +205,14 @@ sub create_related_media : Callback( priority => 6) {
     # Bail on error or when there is no file.
     my $param = $self->params;
     return if $param->{_inconsistent_state_};
-    return unless $param->{"$widget|file"};
+    if (!$param->{'media_prof|at_id'}) {
+        $self->add_message('Please select a media type to upload.');
+        return;
+    }
+    if (!$param->{"$widget|file"}) {
+        $self->add_message('Please select a file to upload.');
+        return;
+    }
 
     # Get a handle on things to restore later.
     my $element = $self->_locate_subelement(


### PR DESCRIPTION
Added status messages to media upload dialog.  Also added a 'blank' default media type selection.
