### PR TITLE
Fix overzealous escaping for localization.

### DIFF
--- a/comp/widgets/wrappers/header.mc
+++ b/comp/widgets/wrappers/header.mc
@@ -37,7 +37,7 @@ for (@context){
     s/\s+$//g;
     if (/^(\"?)(.+?)(\"?)$/) {
         my ($startquote, $text, $endquote) = ($1, $2, $3);
-        $text =~ s/([\[\],~])/~$1/g;
+        $text =~ s/([\[\]~])/~$1/g;
         my $underscores = ($text =~ s/^(_+)//) ? $1 : '';
         $_ = qq{$startquote<span class="110n">$underscores}
           . $lang->maketext($text) . "</span>$endquote";

--- a/t/Bric/Util/Language/Test.pm
+++ b/t/Bric/Util/Language/Test.pm
@@ -19,5 +19,17 @@ sub _test_load : Test(17) {
     closedir LANGS;
 }
 
+##############################################################################
+# Test escaped special characters
+##############################################################################
+sub test_localize : Test(3) {
+    use_ok('Bric::Util::Language');
+    ok(my $lang = Bric::Util::Language->get_handle("de_de"),
+       'Get German translation');
+    is($lang->maketext('Me, ~~myself~~, and ~[I~] ~,'),
+       'Me, ~myself~, and [I] ~,',
+       "Special characters are unescaped properly");
+}
+
 1;
 __END__


### PR DESCRIPTION
Suggested Bric::Changes–

Commas in story and media titles are no longer improperly escaped with tildes. Reported by Michael Herring. (Bug #245)
