### PR TITLE
Fix for bug #280 -- searches using subelement_key_name parameter now only return current versions

### DIFF
--- a/lib/Bric/Biz/Asset/Business/Media.pm
+++ b/lib/Bric/Biz/Asset/Business/Media.pm
@@ -232,7 +232,7 @@ use constant PARAM_WHERE_MAP => {
       expired               => '(i.expire_date IS NOT NULL AND i.expire_date <= CURRENT_TIMESTAMP)',
       desk_id               => 'mt.desk__id = ?',
       name                  => 'LOWER(i.name) LIKE LOWER(?)',
-      subelement_key_name   => 'i.id = mct.object_instance_id AND mct.element_type__id = subet.id AND LOWER(subet.key_name) LIKE LOWER(?)',
+      subelement_key_name   => 'i.id = mct.object_instance_id AND mct.active = TRUE AND mct.element_type__id = subet.id AND LOWER(subet.key_name) LIKE LOWER(?)',
       subelement_id         => 'i.id = sme.object_instance_id AND sme.active = TRUE AND sme.element_type__id = ?',
       related_story_id      => 'i.id = mctrs.object_instance_id AND mctrs.related_story__id = ?',
       related_media_id      => 'i.id = mctrm.object_instance_id AND mctrm.related_media__id = ?',
@@ -295,7 +295,7 @@ use constant PARAM_WHERE_MAP => {
 use constant PARAM_ANYWHERE_MAP => {
     element_key_name       => [ 'mt.element_type__id = e.id',
                                 'LOWER(e.key_name) LIKE LOWER(?)' ],
-    subelement_key_name    => [ 'i.id = mct.object_instance_id AND mct.element_type__id = subet.id',
+    subelement_key_name    => [ 'i.id = mct.object_instance_id AND mct.active = TRUE AND mct.element_type__id = subet.id',
                                 'LOWER(subet.key_name) LIKE LOWER(?)' ],
     subelement_id          => [ 'i.id = sme.object_instance_id AND sme.active = TRUE',
                                 'sme.element_type__id = ?' ],

--- a/lib/Bric/Biz/Asset/Business/Story.pm
+++ b/lib/Bric/Biz/Asset/Business/Story.pm
@@ -338,7 +338,7 @@ use constant PARAM_WHERE_MAP => {
       expired                => '(i.expire_date IS NOT NULL AND i.expire_date <= CURRENT_TIMESTAMP)',
       desk_id                => 's.desk__id = ?',
       name                   => 'LOWER(i.name) LIKE LOWER(?)',
-      subelement_key_name    => 'i.id = sct.object_instance_id AND sct.element_type__id = subet.id AND LOWER(subet.key_name) LIKE LOWER(?)',
+      subelement_key_name    => 'i.id = sct.object_instance_id AND sct.active = TRUE AND sct.element_type__id = subet.id AND LOWER(subet.key_name) LIKE LOWER(?)',
       subelement_id          => 'i.id = sse.object_instance_id AND sse.active = TRUE AND sse.element_type__id = ?',
       related_story_id       => 'i.id = sctrs.object_instance_id AND sctrs.related_story__id = ?',
       related_media_id       => 'i.id = sctrm.object_instance_id AND sctrm.related_media__id = ?',
@@ -418,7 +418,7 @@ use constant PARAM_WHERE_MAP => {
 use constant PARAM_ANYWHERE_MAP => {
     element_key_name       => [ 's.element_type__id = e.id',
                                 'LOWER(e.key_name) LIKE LOWER(?)' ],
-    subelement_key_name    => [ 'i.id = sct.object_instance_id AND sct.element_type__id = subet.id',
+    subelement_key_name    => [ 'i.id = sct.object_instance_id AND sct.active = TRUE AND sct.element_type__id = subet.id',
                                 'LOWER(subet.key_name) LIKE LOWER(?)' ],
     subelement_id          => [ 'i.id = sse.object_instance_id AND sse.active = TRUE',
                                 'sse.element_type__id = ?' ],


### PR DESCRIPTION
Hi everybody,

This bug affects searches for stories and media using the subelement_key_name parameter. 

At the moment, documents that contained a subelement in a previous version, but do not contain it in the current one, are returned incorrectly in a search.

This patch just adds a check to be sure the subelement records are active.

Thanks so much,

Bret
