### PR TITLE
Fix related link edit pagination

### DIFF
--- a/comp/workflow/profile/story/container/edit_related_story.html
+++ b/comp/workflow/profile/story/container/edit_related_story.html
@@ -22,12 +22,18 @@ my $context = "Workflow | Profile | $sdisp | $disp |";
 </%once>
 
 <%args>
-$id
+$id => undef
 </%args>
 
 <%init>;
 my $crumb = get_state_data('container_prof', 'crumb') || '';
 $crumb .= ' |' if $crumb;
+if ($id) {
+    set_state_data('container_prof', relate_to_id => $id);
+} else {
+    $id = get_state_data('container_prof', 'relate_to_id');
+}
+die "no value sent for required parameter 'id'" unless $id;
 </%init>
 
 <%doc>


### PR DESCRIPTION
$id arg wasn't being preserved on pagination causing a fatal error.
Modified the template to just do the same thing that
edit_related_media.html does.
