### PR TITLE
Fix encoding error in POD.

### DIFF
--- a/lib/Bric/License.pod
+++ b/lib/Bric/License.pod
@@ -1,3 +1,5 @@
+=encoding utf8
+
 =head1 Name
 
 Bric::License - The Bricolage License.


### PR DESCRIPTION
Simple fix. The lack of an encoding specification causes "make dist" to fail on my system.