### PR TITLE
Remove unecessary required dependency on Digest::SHA1

### DIFF
--- a/lib/Bric/Admin.pod
+++ b/lib/Bric/Admin.pod
@@ -354,8 +354,6 @@ START MODULE LIST
 
 =item Digest::MD5
 
-=item Digest::SHA1 2.01
-
 =item URI
 
 =item HTML::Tagset


### PR DESCRIPTION
AFAICT, there is nothing in the code that uses this module. It's one of two required dependencies that can't be satisfied from standard Debian packages.